### PR TITLE
Update for qt6

### DIFF
--- a/src/gui/deckconf.py
+++ b/src/gui/deckconf.py
@@ -1,6 +1,6 @@
-from aqt import mw
 from aqt.qt import QWidget, QLabel, QSpinBox, QCheckBox, QGridLayout, QVBoxLayout
 from aqt.deckconf import DeckConf
+from anki.lang import _
 
 from aqt.gui_hooks import (
     deck_conf_did_load_config,
@@ -11,7 +11,6 @@ from aqt.gui_hooks import (
 from ..config import (
     StraightSetting,
     get_setting_from_config,
-    serialize_setting,
     deserialize_setting,
     write_setting,
 )

--- a/src/lib/logic.py
+++ b/src/lib/logic.py
@@ -1,9 +1,6 @@
-from PyQt5 import QtWidgets, Qt
 from anki.cards import Card
-from anki.collection import Collection
+from aqt.qt import *
 
-from enum import IntEnum
-from sys import maxsize
 from itertools import takewhile
 from typing import List, Tuple, Literal
 

--- a/src/lib/review_hook.py
+++ b/src/lib/review_hook.py
@@ -6,7 +6,6 @@ from aqt.utils import tooltip
 
 from anki.hooks import card_will_flush
 from anki.consts import CARD_TYPE_REV, REVLOG_REV
-from anki.collection import Collection
 from anki.cards import Card
 
 from .logic import (

--- a/src/lib/sync_hook.py
+++ b/src/lib/sync_hook.py
@@ -2,7 +2,6 @@ from typing import List, Tuple, Dict, Optional, Any, Callable
 from pathlib import Path
 from datetime import datetime
 
-from anki.collection import Collection
 from anki.cards import Card
 from anki.rsbackend import NotFoundError
 


### PR DESCRIPTION
I just replaced an import from PyQt5 with one from aqt.qt to make it more future proof (and cleaned up other imports). The add-on works in Anki 2.1.50 with qt6.