### PR TITLE
Fix error on Anki 2.1.66 (fixes #32)

### DIFF
--- a/src/lib/review_hook.py
+++ b/src/lib/review_hook.py
@@ -13,6 +13,7 @@ from anki.hooks import card_will_flush
 from anki.consts import CARD_TYPE_REV, REVLOG_REV
 from anki.collection import Collection
 from anki.cards import Card
+from anki.scheduler.v3 import SetSchedulingStatesRequest
 
 from .logic import (
     get_straight_len,
@@ -67,7 +68,11 @@ def check_straight_reward(
         else:
             next_states.easy.normal.review.ease_factor += easeplus / 1000
 
-        reviewer.set_scheduling_states(reviewer._state_mutation_key, next_states)
+        request = SetSchedulingStatesRequest(
+            key=reviewer._state_mutation_key,
+            states=next_states,
+        )
+        reviewer.set_scheduling_states(request)
     else:
         gains[card.id] = easeplus
 


### PR DESCRIPTION
This patch updates the `reviewer.set_scheduling_states()` call to use the new API introduced in [ankitects/anki@`92e33b7` (#2547)](https://github.com/ankitects/anki/pull/2547/commits/92e33b7f2d364c029f7e9e8bbf9e7d182f9e4e44).
At this point, merging it will drop support for older Anki versions. I can add backward compatibility code if needed.